### PR TITLE
Add GitHub aciton for publishing to NuGet

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -1,0 +1,30 @@
+name: publish to nuget
+on:
+  push:
+    branches:
+      - main # Default release branch
+jobs:
+  publish:
+    name: build, pack & publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup dotnet sdk
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "3.1.x"
+          include-prerelease: true
+
+      - name: publish on version change
+        id: publish_nuget
+        uses: rohith/publish-nuget@v2
+        with:
+          # Filepath of the project to be packaged, relative to root of repository
+          PROJECT_FILE_PATH: src/Grok.Net/Grok.Net.csproj
+          PACKAGE_NAME: grok.net
+
+          TAG_COMMIT: true
+          TAG_FORMAT: v*
+
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}


### PR DESCRIPTION
We should also add repository secret named `NUGET_API_KEY` to be able to publish the nuget package. 
Closes #33 