### PR TITLE
Changed custom pattern handling to not silently ignore errors and other minor improvements

### DIFF
--- a/src/Grok.Net.Tests/UnitTests.cs
+++ b/src/Grok.Net.Tests/UnitTests.cs
@@ -195,6 +195,30 @@ namespace GrokNetTests
             Assert.Equal(zipcode, grokResult[0].Value);
             Assert.Equal(email, grokResult[1].Value);
         }
+        
+        [Theory]
+        [InlineData("122001")]
+        [InlineData("122 001")]
+        [InlineData("235 012")]
+        public void Load_Custom_Patterns_From_IEnumberable(string zipcode)
+        {
+            // Arrange
+            var customPatterns = new[]
+            {
+                ("ZIPCODE", "[1-9]{1}[0-9]{2}\\s{0,1}[0-9]{3}"), 
+                ("FLOAT", "[+-]?([0-9]*[.,])?[0-9]+"),
+            };
+            const string email = "Bob.Davis@microsoft.com";
+
+            var sut = new Grok("%{ZIPCODE:zipcode}:%{EMAILADDRESS:email}", customPatterns);
+
+            // Act
+            GrokResult grokResult = sut.Parse($"{zipcode}:{email}");
+
+            // Assert
+            Assert.Equal(zipcode, grokResult[0].Value);
+            Assert.Equal(email, grokResult[1].Value);
+        }        
 
         [Fact]
         public void Load_Wrong_Custom_Patterns()
@@ -211,6 +235,7 @@ namespace GrokNetTests
                 GrokResult grokResult = sut.Parse($"{duration}:{client}");
 
                 // Assert (checks if regex is invalid)
+                Assert.Equal(2, sut.PatternViolations.Count);
                 Assert.Equal("", grokResult[0].Value);
                 Assert.Equal("", grokResult[1].Value);
             }


### PR DESCRIPTION
Hey there,

here is the PR you mentioned in  #52.

Some notes:
- I added a constructor for adding custom patterns by `IEnumerable<(string, string)>`, because I thought `Stream` is not neccessary in all the use cases
- I noticed, that the default constructor loads custom patterns from a manifest file and added a comment, if this is a good idea
- While the `PatternViolations` list I added might be a quick fix for the *silently ignores errors* problem, I'm not sure, that this is a good design decision in the long term. I would think over an API redesign calling `Grok` static with a fluent interface, example see below (just an idea, maybe we should discuss that as soon as you have more time):

```c#
try {
  var matcher = Grok.Define("%{ZIPCODE:zipcode}:%{EMAILADDRESS:email}").WithPatterns(new[] {
      ("ZIPCODE", "[1-9]{1}[0-9]{2}\\s{0,1}[0-9]{3}"), 
      ("FLOAT", "[+-]?([0-9]*[.,])?[0-9]+"),
  });
  
  if(matcher.TryMatch("122 001:Bob.Davis@microsoft.com", out var matches)) {
    Console.WriteLine("Matches found: " + matches.Count);
  } else {
    Console.WriteLine("No matches found");
  };
} catch(GrokDefinitionException e) {
  Console.WriteLine("Invalid definition: " + e.Message);
} catch(GrokPatternException pe) {
  Console.WriteLine("Invalid custom pattern: " + e.Message);
}
```