### PR TITLE
Get Dictionary instead of GrokResult with AsDictionary method (#72)

### DIFF
--- a/src/Grok.Net/Grok.cs
+++ b/src/Grok.Net/Grok.cs
@@ -86,41 +86,6 @@ namespace GrokNet
             return new GrokResult(grokItems);
         }
 
-        public Dictionary<string, List<object>> AsDictionary(string text)
-        {
-            if (_compiledRegex == null)
-            {
-                ParsePattern();
-            }
-
-            var items = new Dictionary<string, List<object>>();
-
-            foreach (Match match in _compiledRegex.Matches(text))
-            {
-                foreach (string groupName in _patternGroupNames)
-                {
-                    if (groupName != "0")
-                    {
-                        string groupValue = match.Groups[groupName].Value;
-
-                        var value = _typeMaps.TryGetValue(groupName, out string mappedType)
-                            ? MapType(mappedType, groupValue)
-                            : groupValue;
-
-                        if (items.ContainsKey(groupName))
-                        {
-                            items[groupName].Add(value);
-                        }
-                        else
-                        {
-                            items.Add(groupName, new List<object>() { value });
-                        }
-                    }
-                }
-            }
-            return items;
-        }
-
         private void AddCustomPatterns(IDictionary<string, string> customPatterns)
         {
             foreach (var pattern in customPatterns)

--- a/src/Grok.Net/Grok.cs
+++ b/src/Grok.Net/Grok.cs
@@ -86,6 +86,41 @@ namespace GrokNet
             return new GrokResult(grokItems);
         }
 
+        public Dictionary<string, List<object>> AsDictionary(string text)
+        {
+            if (_compiledRegex == null)
+            {
+                ParsePattern();
+            }
+
+            var items = new Dictionary<string, List<object>>();
+
+            foreach (Match match in _compiledRegex.Matches(text))
+            {
+                foreach (string groupName in _patternGroupNames)
+                {
+                    if (groupName != "0")
+                    {
+                        string groupValue = match.Groups[groupName].Value;
+
+                        var value = _typeMaps.TryGetValue(groupName, out string mappedType)
+                            ? MapType(mappedType, groupValue)
+                            : groupValue;
+
+                        if (items.ContainsKey(groupName))
+                        {
+                            items[groupName].Add(value);
+                        }
+                        else
+                        {
+                            items.Add(groupName, new List<object>() { value });
+                        }
+                    }
+                }
+            }
+            return items;
+        }
+
         private void AddCustomPatterns(IDictionary<string, string> customPatterns)
         {
             foreach (var pattern in customPatterns)

--- a/src/Grok.Net/GrokResult.cs
+++ b/src/Grok.Net/GrokResult.cs
@@ -11,7 +11,7 @@ namespace GrokNet
         {
         }
 
-        public Dictionary<string, IEnumerable<object>> ToDictionary() => Items
+        public IReadOnlyDictionary<string, IEnumerable<object>> ToDictionary() => Items
             .GroupBy(grokItem => grokItem.Key)
             .ToDictionary(groupName => groupName.Key, grokItems => grokItems.Select(grokItem => grokItem.Value));
     }

--- a/src/Grok.Net/GrokResult.cs
+++ b/src/Grok.Net/GrokResult.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace GrokNet
 {
@@ -9,5 +10,9 @@ namespace GrokNet
             : base(grokItems ?? new List<GrokItem>())
         {
         }
+
+        public Dictionary<string, IEnumerable<object>> ToDictionary() => Items
+            .GroupBy(grokItem => grokItem.Key)
+            .ToDictionary(groupName => groupName.Key, grokItems => grokItems.Select(grokItem => grokItem.Value));
     }
 }


### PR DESCRIPTION
```cs
Grok grok = new Grok("%{MONTHDAY:month}-%{MONTHDAY:day}-%{MONTHDAY:year} %{TIME:timestamp};%{WORD:id};%{LOGLEVEL:loglevel};%{WORD:func};%{GREEDYDATA:msg}");

string logs = @"06-21-19 21:00:13:589241;15;INFO;main;DECODED: 775233900043 DECODED BY: 18500738 DISTANCE: 1.5165
                06-22-19 22:00:13:589265;156;WARN;main;DECODED: 775233900043 EMPTY DISTANCE: --------";

var grokResult = grok.AsDictionary(logs);

foreach (var item in grokResult)
{
    Console.WriteLine($"{item.Key}:");
    foreach (var value in item.Value)
    {
        Console.WriteLine("\t" + value);
    }
}
```

this will now print:

```
month:
        06
        06
day:
        21
        22
year:
        19
        19
timestamp:
        21:00:13:589241
        22:00:13:589265
id:
        15
        156
loglevel:
        INFO
        WARN
func:
        main
        main
msg:
        DECODED: 775233900043 DECODED BY: 18500738 DISTANCE: 1.5165
        DECODED: 775233900043 EMPTY DISTANCE: --------
```