### PR TITLE
Validation for Grok patterns

### DIFF
--- a/src/Grok.Net.Tests/UnitTests.cs
+++ b/src/Grok.Net.Tests/UnitTests.cs
@@ -400,7 +400,7 @@ namespace GrokNetTests
         [Fact]
         public void InvalidPattern_ThrowsException()
         {
-            // Arrange            
+            // Arrange
             const string logs = @"06-21-19 21:00:13:589241;15;INFO;main;DECODED: 775233900043 DECODED BY: 18500738 DISTANCE: 1.5165
             06-22-19 22:00:13:589265;156;WARN;main;DECODED: 775233900043 EMPTY DISTANCE: --------";
 

--- a/src/Grok.Net.Tests/UnitTests.cs
+++ b/src/Grok.Net.Tests/UnitTests.cs
@@ -418,7 +418,7 @@ namespace GrokNetTests
             const string zipcode = "122001";
             const string email = "Bob.Davis@microsoft.com";
 
-            var sut = new Grok("%{ZIPCOD:zipcode}:%{EMAILADDRESS:email}", ReadCustomFile());            
+            var sut = new Grok("%{ZIPCOD:zipcode}:%{EMAILADDRESS:email}", ReadCustomFile());
 
             // Act & Assert
             FormatException exception = Assert.Throws<FormatException>(() => sut.Parse($"{zipcode}:{email}"));

--- a/src/Grok.Net/Grok.cs
+++ b/src/Grok.Net/Grok.cs
@@ -291,7 +291,7 @@ namespace GrokNet
         private void ValidateGrokPattern(string grokPattern)
         {
             var grokPatternRegex = new PcreRegex("%\\{([^:}]+)(?::[^}]+)?(?::[^}]+)?\\}");
-            IEnumerable<PcreMatch> matches = grokPatternRegex.Matches(grokPattern);
+            IEnumerable<PcreMatch> matches = grokPatternRegex.Matches(_grokPattern);
 
             foreach (PcreMatch match in matches)
             {

--- a/src/Grok.Net/Grok.cs
+++ b/src/Grok.Net/Grok.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using PCRE;
 
 namespace GrokNet
@@ -104,6 +105,7 @@ namespace GrokNet
         {
             if (_compiledRegex == null)
             {
+                ValidateGrokPattern(_grokPattern);
                 ParsePattern();
             }
 
@@ -285,6 +287,21 @@ namespace GrokNet
             }
 
             return "()";
+        }
+
+        private void ValidateGrokPattern(string grokPattern)
+        {
+            var grokPatternRegex = new Regex("%\\{([^:}]+)(?::[^}]+)?(?::[^}]+)?\\}");
+            MatchCollection matches = grokPatternRegex.Matches(grokPattern);
+
+            foreach (Match match in matches.Cast<Match>())
+            {
+                var patternName = match.Groups[1].Value;
+                if (!_patterns.ContainsKey(patternName))
+                {
+                    throw new FormatException($"Invalid Grok pattern: Pattern '{patternName}' not found.");
+                }
+            }
         }
     }
 }

--- a/src/Grok.Net/Grok.cs
+++ b/src/Grok.Net/Grok.cs
@@ -288,7 +288,7 @@ namespace GrokNet
             return "()";
         }
 
-        private void ValidateGrokPattern(string grokPattern)
+        private void ValidateGrokPattern()
         {
             var grokPatternRegex = new PcreRegex("%\\{([^:}]+)(?::[^}]+)?(?::[^}]+)?\\}");
             IEnumerable<PcreMatch> matches = grokPatternRegex.Matches(_grokPattern);

--- a/src/Grok.Net/Grok.cs
+++ b/src/Grok.Net/Grok.cs
@@ -1,10 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
 using PCRE;
 
 namespace GrokNet
@@ -291,10 +290,10 @@ namespace GrokNet
 
         private void ValidateGrokPattern(string grokPattern)
         {
-            var grokPatternRegex = new Regex("%\\{([^:}]+)(?::[^}]+)?(?::[^}]+)?\\}");
-            MatchCollection matches = grokPatternRegex.Matches(grokPattern);
+            var grokPatternRegex = new PcreRegex("%\\{([^:}]+)(?::[^}]+)?(?::[^}]+)?\\}");
+            IEnumerable<PcreMatch> matches = grokPatternRegex.Matches(grokPattern);
 
-            foreach (Match match in matches.Cast<Match>())
+            foreach (PcreMatch match in matches)
             {
                 var patternName = match.Groups[1].Value;
                 if (!_patterns.ContainsKey(patternName))

--- a/src/Grok.Net/Grok.cs
+++ b/src/Grok.Net/Grok.cs
@@ -104,7 +104,7 @@ namespace GrokNet
         {
             if (_compiledRegex == null)
             {
-                ValidateGrokPattern(_grokPattern);
+                ValidateGrokPattern();
                 ParsePattern();
             }
 


### PR DESCRIPTION
This enhancement adds validation to ensure that all Grok patterns specified in an expression are defined within the loaded patterns set

Related to issue #77 